### PR TITLE
Fix: Adjust footer column layout for better alignment

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -884,7 +884,12 @@ giving them the correct small size and right-alignment.
         grid-template-columns: repeat(3, 1fr);
     }
 
-    .footer-grid { grid-template-columns: repeat(3, 1fr); text-align: left; }
+    .footer-grid { 
+        /* This gives the center column more space (1.5fr vs 1fr) */
+        grid-template-columns: 1fr 1.5fr 1fr; 
+        text-align: left; 
+    }
+
     #social-column, #partners-column { display: block; } /* Show hidden footer columns */
     .footer-column h4, #contact-info-column { text-align: center; }
     .partner-logos { justify-content: center; }


### PR DESCRIPTION
### Summary

This is a minor style correction to improve the visual alignment of the footer on desktop screen sizes (`992px` and wider).

### Problem

The center column of the footer, containing the company's contact information, was not wide enough to prevent the address from wrapping to a second line on certain screen resolutions. This created an unbalanced and unprofessional appearance.

### Solution

The `grid-template-columns` property for the `.footer-grid` has been adjusted from `repeat(3, 1fr)` to `1fr 1.5fr 1fr`. This gives the center column more horizontal space, allowing the address to fit on a single line without negatively impacting the layout of the other two columns. This ensures a clean and balanced presentation of the footer content on all desktop displays.