### PR TITLE
Fix: Correct Google Analytics Snippet Placement for Verification

### DIFF
--- a/Front-End/contact-us.html
+++ b/Front-End/contact-us.html
@@ -22,17 +22,17 @@
     <meta name="twitter:title" content="Get in Touch with CES IT Services in Frederick, MD">
     <meta name="twitter:description" content="Have questions about managed IT or cybersecurity? Contact our team serving Frederick, MD and the surrounding areas today for a consultation.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/contact-us-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body class="contact-us-page">
 

--- a/Front-End/index.html
+++ b/Front-End/index.html
@@ -20,17 +20,17 @@
     <meta name="twitter:title" content="CES IT Services | Expert IT Support in Frederick, MD">
     <meta name="twitter:description" content="Specializing in managed IT, AI Driven Video Surveillance, and VoIP solutions for businesses in Frederick, MD and surrounding areas.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/homepage-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body>
 

--- a/Front-End/managed-services.html
+++ b/Front-End/managed-services.html
@@ -22,17 +22,17 @@
     <meta name="twitter:title" content="CES IT Services | Expert Managed IT for Frederick Businesses">
     <meta name="twitter:description" content="Expert managed IT services for businesses in Frederick, MD and the surrounding areas. Discover customized solutions to keep your business secure, efficient, and scalable.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/managed-services-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body class="managed-services-page">
 

--- a/Front-End/testimonials.html
+++ b/Front-End/testimonials.html
@@ -23,17 +23,17 @@
     <meta name="twitter:title" content="CES IT Services | Client Testimonials">
     <meta name="twitter:description" content="Read reviews testimonials from our valued clients and learn why we are a trusted IT partner for businesses in the Frederick, MD and the surrounding area.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/testimonials-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body class="testimonials-page">
 

--- a/Front-End/video-surveillance.html
+++ b/Front-End/video-surveillance.html
@@ -22,17 +22,17 @@
     <meta name="twitter:title" content="CES IT Services | AI Driven Video Surveillance Solutions">
     <meta name="twitter:description" content="Protect your assets with AI Driven Video Surveillance, featuring smart analytics and intelligent alerts for businesses in Frederick, MD and the surrounding areas.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/video-surveillance-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body class="video-surveillance-page">
 

--- a/Front-End/voip-solutions.html
+++ b/Front-End/voip-solutions.html
@@ -22,17 +22,17 @@
     <meta name="twitter:title" content="CES IT Services | VoIP Phone Systems for Frederick, MD">
     <meta name="twitter:description" content="Enhance communications with advanced VoIP solutions, including auto-attendants and call analytics, for businesses in Frederick, MD and the surrounding areas.">
     <meta name="twitter:image" content="https://www.cesitservice.com/images/social/voip-solutions-share.jpg">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CKYYMEZ3V4');
+    </script>
+
 </head>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CKYYMEZ3V4"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CKYYMEZ3V4');
-</script>
 
 <body class="voip-solutions-page">
 


### PR DESCRIPTION
Description:

This pull request resolves an issue preventing Google Search Console ownership verification by correcting the placement of the Google Analytics (gtag.js) tracking snippet.

Problem:
The Google Analytics tracking code was previously located outside of the <head> section in the site's HTML files. According to Google's documentation, for site ownership to be verified using the Google Analytics method, the tracking snippet must be present within the <head> section of the homepage. This incorrect placement was blocking the verification process.

Solution:
This branch (fix/google-analytics-placement) contains a commit that programmatically moves the entire Google Analytics snippet into the <head> section on all .html pages across the site. This ensures that the script is in the correct location for verification and adheres to Google's recommended best practices for optimal tracking performance.

Changes:

The Google Analytics (gtag.js) script has been moved to just before the closing </head> tag on all HTML pages.

The duplicate script has been removed.

Once this pull request is merged, you should be able to proceed with the Google Search Console verification without any further issues.